### PR TITLE
Comments limitation

### DIFF
--- a/MapApp/Controllers/CommentsController.cs
+++ b/MapApp/Controllers/CommentsController.cs
@@ -53,12 +53,16 @@ namespace MapApp.Controllers
                 return NotFound();
             }
 
-            var comment = await _context.Location
+            var isLocExist = await _context.Location
                 .SingleOrDefaultAsync(m => m.ID == loc_id);
-            if (comment == null)
+            if (isLocExist == null)
             {
                 return NotFound();
             }
+
+            // Check if this user wrote more than one comment for this location
+            if (IsDoubled(await _context.Comment.ToListAsync(), loc_id, User.Identity.Name))
+                return RedirectToAction("DoubleComment");
 
             ViewBag.loc_id = loc_id;
             ViewBag.User = User.Identity.Name;
@@ -72,6 +76,10 @@ namespace MapApp.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Create([Bind("ID,Header,Content,User,Location")] Comment comment)
         {
+            if (IsDoubled(await _context.Comment.ToListAsync(), comment.Location, User.Identity.Name))
+                return RedirectToAction("DoubleComment");
+
+
             if (ModelState.IsValid)
             {
                 comment.EditTime = comment.CreateTime = DateTime.Now;
@@ -170,6 +178,24 @@ namespace MapApp.Controllers
         private bool CommentExists(int id)
         {
             return _context.Comment.Any(e => e.ID == id);
+        }
+
+        public IActionResult DoubleComment()
+        {
+            return View();
+        }
+
+        // Check if there's more than one comment for a location of the same user
+        public static bool IsDoubled(IEnumerable<Comment> comments, int? loc_id, string user)
+        {
+            var result =
+                from com in comments
+                where com.Location.Equals(loc_id) && com.User.Equals(user)
+                select com;
+            if (result.Any())
+                return true;
+            else
+                return false;
         }
     }
 }

--- a/MapApp/Controllers/LocationsController.cs
+++ b/MapApp/Controllers/LocationsController.cs
@@ -62,11 +62,17 @@ namespace MapApp.Controllers
 				return NotFound();
 			}
 
+            // Gets the location's comments
             var comments = await _context.Comment.ToListAsync();
             var result =
                 from com in comments
                 where com.Location.Equals(id)
                 select com;
+
+            ViewBag.Doubled = false;
+            if (CommentsController.IsDoubled(comments, id, User.Identity.Name))
+                ViewBag.Doubled = true;
+
             ViewBag.Comments = result;
             ViewBag.User = User.Identity.Name;
             ViewBag.Admin = User.IsInRole("Administrator");
@@ -255,5 +261,11 @@ namespace MapApp.Controllers
 			//location.Image = Convert.ToBase64String(location.Image);
 			location.User = User.Identity.Name;
 		}
-	}
+
+        public IActionResult DoubleComment()
+        {
+            return View();
+        }
+
+    }
 }

--- a/MapApp/Views/Comments/DoubleComment.cshtml
+++ b/MapApp/Views/Comments/DoubleComment.cshtml
@@ -1,0 +1,10 @@
+@{
+    ViewData["Title"] = "DoubleComment";
+}
+
+<header>
+    <h1 class="text-danger">Double Comment</h1>
+    <p class="text-danger">You can not write more than one comment per location.</p>
+</header>
+
+

--- a/MapApp/Views/Locations/Details.cshtml
+++ b/MapApp/Views/Locations/Details.cshtml
@@ -110,9 +110,9 @@
                     @item.User
                 </td>
                 <td>
-                    @if(item.User == ViewBag.User || ViewBag.Admin){<a asp-action="../Comments/Edit" asp-route-id="@item.ID">Edit</a> @Html.Raw(" | ")  }
+                    @if (item.User == ViewBag.User || ViewBag.Admin) {<a asp-action="../Comments/Edit" asp-route-id="@item.ID">Edit</a> @Html.Raw(" | ")  }
                     <a asp-action="../Comments/Details" asp-route-id="@item.ID">Details</a>
-                    @if (item.User == ViewBag.User || ViewBag.Admin){@Html.Raw(" | ")<a asp-action="../Comments/Delete" asp-route-id="@item.ID">Delete</a>  }
+                    @if (item.User == ViewBag.User || ViewBag.Admin) {@Html.Raw(" | ")<a asp-action="../Comments/Delete" asp-route-id="@item.ID">Delete</a>  }
                 </td>
             </tr>
         }
@@ -120,7 +120,8 @@
 </table>
 
 <p>
-    <a asp-action="../Comments/Create" asp-route-loc_id="@Model.ID">New comment</a>
+    @if (ViewBag.Doubled){ <span data-toggle="tooltip" title="You are allowed only one comment per lacation" style="color:gray">New comment</span> }
+    else{ <a asp-action="../Comments/Create" asp-route-loc_id="@Model.ID">New comment</a> }
 </p>
 
 


### PR DESCRIPTION
Limits one comment per location for the same user
Added as a prerequisite for "Rating" feature (means one user cannot rate location more than once).